### PR TITLE
Split task action handlers into atomic modules

### DIFF
--- a/src/reducers/taskReducer.ts
+++ b/src/reducers/taskReducer.ts
@@ -1,35 +1,27 @@
 import type { Task, TaskAction } from '../types/task.types';
+import {
+    addTask,
+    toggleTask,
+    deleteTask,
+    editTask,
+    clearCompletedTasks,
+    loadTasks,
+} from './tasks';
 
 export const tasksReducer = (state: Task[], action: TaskAction): Task[] => {
     switch (action.type) {
         case 'ADD_TASK':
-            return [
-                ...state,
-                {
-                    id: Date.now(),
-                    text: action.payload,
-                    completed: false,
-                    createdAt: new Date()
-                }
-            ];
+            return addTask(state, action.payload);
         case 'TOGGLE_TASK':
-            return state.map(task =>
-                task.id === action.payload
-                    ? { ...task, completed: !task.completed }
-                    : task
-            );
+            return toggleTask(state, action.payload);
         case 'DELETE_TASK':
-            return state.filter(task => task.id !== action.payload);
+            return deleteTask(state, action.payload);
         case 'EDIT_TASK':
-            return state.map(task =>
-                task.id === action.payload.id
-                    ? { ...task, text: action.payload.text }
-                    : task
-            );
+            return editTask(state, action.payload);
         case 'CLEAR_COMPLETED':
-            return state.filter(task => !task.completed);
+            return clearCompletedTasks(state);
         case 'LOAD_TASKS':
-            return action.payload;
+            return loadTasks(action.payload);
         default:
             return state;
     }

--- a/src/reducers/tasks/addTask.ts
+++ b/src/reducers/tasks/addTask.ts
@@ -1,0 +1,11 @@
+import type { Task } from '../../types/task.types';
+
+export const addTask = (state: Task[], text: string): Task[] => [
+    ...state,
+    {
+        id: Date.now(),
+        text,
+        completed: false,
+        createdAt: new Date(),
+    },
+];

--- a/src/reducers/tasks/clearCompletedTasks.ts
+++ b/src/reducers/tasks/clearCompletedTasks.ts
@@ -1,0 +1,4 @@
+import type { Task } from '../../types/task.types';
+
+export const clearCompletedTasks = (state: Task[]): Task[] =>
+    state.filter(task => !task.completed);

--- a/src/reducers/tasks/deleteTask.ts
+++ b/src/reducers/tasks/deleteTask.ts
@@ -1,0 +1,4 @@
+import type { Task } from '../../types/task.types';
+
+export const deleteTask = (state: Task[], id: number): Task[] =>
+    state.filter(task => task.id !== id);

--- a/src/reducers/tasks/editTask.ts
+++ b/src/reducers/tasks/editTask.ts
@@ -1,0 +1,9 @@
+import type { Task } from '../../types/task.types';
+
+export const editTask = (
+    state: Task[],
+    payload: { id: number; text: string }
+): Task[] =>
+    state.map(task =>
+        task.id === payload.id ? { ...task, text: payload.text } : task
+    );

--- a/src/reducers/tasks/index.ts
+++ b/src/reducers/tasks/index.ts
@@ -1,0 +1,6 @@
+export { addTask } from './addTask';
+export { toggleTask } from './toggleTask';
+export { deleteTask } from './deleteTask';
+export { editTask } from './editTask';
+export { clearCompletedTasks } from './clearCompletedTasks';
+export { loadTasks } from './loadTasks';

--- a/src/reducers/tasks/loadTasks.ts
+++ b/src/reducers/tasks/loadTasks.ts
@@ -1,0 +1,3 @@
+import type { Task } from '../../types/task.types';
+
+export const loadTasks = (tasks: Task[]): Task[] => tasks;

--- a/src/reducers/tasks/toggleTask.ts
+++ b/src/reducers/tasks/toggleTask.ts
@@ -1,0 +1,6 @@
+import type { Task } from '../../types/task.types';
+
+export const toggleTask = (state: Task[], id: number): Task[] =>
+    state.map(task =>
+        task.id === id ? { ...task, completed: !task.completed } : task
+    );


### PR DESCRIPTION
This PR refactors the existing taskReducer.ts file by splitting all task-related action handlers into separate atomic modules. The main goal is to improve code modularity, readability, and maintainability.

Changes Made:
- Extracted each task action handler (addTask, editTask, deleteTask, toggleTask, loadTasks, clearCompletedTasks) into its own file.
- Updated tasksReducer to import handlers from the new atomic structure.
- Created a central index file to re-export all task actions for cleaner imports.

Benefits:
- Easier to test and maintain individual action logic.
- Improves code scalability for future enhancements.
- Aligns with clean architecture and separation of concerns principles.